### PR TITLE
feat: refactor testeGerenteBonusAnualPositivo test

### DIFF
--- a/tests/FuncionarioTest.php
+++ b/tests/FuncionarioTest.php
@@ -139,14 +139,8 @@ public function testCriaInstanciaGerenteComHeranca()
 
     public function testGerenteBonusAnualPositivo()
     {
-        try {
-            $gerente = new Gerente('Julia', 9000, 10000);
-            $this->assertGreaterThanOrEqual(0, $gerente->getBonusAnual());
-            $this->addTestResult(__FUNCTION__, 'pass');
-        } catch (\Throwable $e) {
-            $this->addTestResult(__FUNCTION__, 'fail', $e->getMessage());
-            throw $e;
-        }
+        $gerente = new Gerente('Julia', 9000, 10000);
+        $this->assertGreaterThanOrEqual(0, $gerente->getBonusAnual());
     }
 
     public function testDesenvolvedorLinguagemPrincipalNaoVazia()


### PR DESCRIPTION
🚫 Problemas no teste atual:
try/catch não é necessário em testes de unidade — se algo falhar, o próprio PHPUnit já marca como erro/falha.

O uso de addTestResult(__FUNCTION__, ...) indica que você está tentando logar ou rastrear manualmente os testes, o que não é prática comum (isso deve ser feito via eventos do PHPUnit, se necessário).

O if($e != null) é redundante: se o catch capturou, é porque já há uma exceção.

todos solucionados e teste refatorado com sucesso.